### PR TITLE
fix: customindex-hard-coded-embed-model

### DIFF
--- a/src/llama_utils/indexing/custom_index.py
+++ b/src/llama_utils/indexing/custom_index.py
@@ -121,7 +121,10 @@ class CustomIndex:
 
     @classmethod
     def create_from_documents(
-        cls, document: List[Union[Document, str]], generate_id: bool = True
+        cls,
+        document: List[Union[Document, str]],
+        generate_id: bool = True,
+        embedding_model=None,
     ) -> "CustomIndex":
         """Create a new index from a document.
 
@@ -131,6 +134,8 @@ class CustomIndex:
             The document to create the index from.
         generate_id: bool, optional, default is False.
             True if you want to generate a sha256 hash number as a doc_id based on the content of the nodes.
+        embedding_model: Optional, default is None.
+            The embedding model to use to create the embeddings in the index.
 
         Returns
         -------
@@ -153,16 +158,20 @@ class CustomIndex:
                 doc.node_id = generate_content_hash(doc.text)
 
         index = VectorStoreIndex.from_documents(docs)
-        return cls(index)
+        return cls(index, embedding_model=embedding_model)
 
     @classmethod
-    def create_from_nodes(cls, nodes: List[TextNode]) -> "CustomIndex":
+    def create_from_nodes(
+        cls, nodes: List[TextNode], embedding_model=None
+    ) -> "CustomIndex":
         """Create a new index from a node.
 
         Parameters
         ----------
         nodes: List[TextNode]
             The nodes to create the index from.
+        embedding_model: Optional, default is None.
+            The embedding model to use to create the embeddings in the index.
 
         Returns
         -------
@@ -186,7 +195,7 @@ class CustomIndex:
         As you see the added node is not a document, so the number of documents is 0.
         """
         index = VectorStoreIndex(nodes)
-        return cls(index)
+        return cls(index, embedding_model=embedding_model)
 
     def add_documents(self, documents: List[Document], generate_id: bool = True):
         """Add documents to the index.

--- a/src/llama_utils/indexing/custom_index.py
+++ b/src/llama_utils/indexing/custom_index.py
@@ -23,7 +23,6 @@ class CustomIndex:
             The index object.
         embedding_model: Optional, default is None.
             The embedding model to use to create the embeddings in the index.
-
         """
         if not isinstance(index, VectorStoreIndex):
             raise ValueError("The index should be an instance of VectorStoreIndex")
@@ -63,9 +62,13 @@ class CustomIndex:
         --------
         ```python
         >>> from llama_utils.utils.config_loader import ConfigLoader
-        >>> config_loader = ConfigLoader()
+        >>> from llama_utils.utils.models import get_hugging_face_embedding
+        >>> embedding_model = get_hugging_face_embedding(model_name="BAAI/bge-small-en-v1.5")
+        >>> config_loader = ConfigLoader(embedding=embedding_model)
+        >>> from llama_index.core.schema import TextNode
+        >>> from llama_utils.indexing.custom_index import CustomIndex
         >>> text_node = TextNode(text="text")
-        >>> index = CustomIndex.create_from_nodes([text_node])
+        >>> index = CustomIndex.create_from_nodes([text_node], embedding_model=embedding_model)
         >>> metadata = index.metadata
         >>> type(metadata)
         <class 'llama_index.core.data_structs.data_structs.IndexDict'>
@@ -145,6 +148,7 @@ class CustomIndex:
         Examples
         --------
         ```python
+        >>> from llama_index.core.schema import Document
         >>> doc = Document(text="text")
         >>> index = CustomIndex.create_from_documents([doc]) # doctest: +SKIP
         >>> type(index) # doctest: +SKIP
@@ -182,10 +186,12 @@ class CustomIndex:
         --------
         To create a new index you have to define the embedding model
         ```python
-        >>> from llama_utils.utils.config_loader import ConfigLoader
-        >>> configs = ConfigLoader()
-        >>> text_node = TextNode(text="text")
-        >>> index = CustomIndex.create_from_nodes([text_node])
+        >>> from llama_index.core.schema import TextNode
+        >>> from llama_utils.indexing.custom_index import CustomIndex
+        >>> from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+        >>> embedding_model = MockEmbedding(embed_dim=768)
+        >>> text_node = TextNode(text="text") # doctest: +SKIP
+        >>> index = CustomIndex.create_from_nodes([text_node], embedding_model=embedding_model) # doctest: +SKIP
         >>> print(index) # doctest: +SKIP
         <BLANKLINE>
                 Index ID: 8d57e294-fd17-43c9-9dec-a12aa7ea0751
@@ -219,13 +225,13 @@ class CustomIndex:
         Set the ConfigLoader to define the embedding model that you want to use to create the embeddings in the index:
         ```python
         >>> from llama_utils.utils.config_loader import ConfigLoader
-        >>> configs = ConfigLoader()
+        >>> configs = ConfigLoader() # doctest: +SKIP
 
         ```
         Create a new index from a document:
         ```python
         >>> doc = Document(text="text", id_="doc 1")
-        >>> index = CustomIndex.create_from_documents([doc])
+        >>> index = CustomIndex.create_from_documents([doc])  # doctest: +SKIP
         >>> print(index) # doctest: +SKIP
         <BLANKLINE>
                 Index ID: 91dd8a18-3ab5-41ca-b8de-998077b9235c
@@ -234,19 +240,19 @@ class CustomIndex:
         ```
         Add a new document to the index:
         ```python
-        >>> doc2 = Document(text="text2", id_="doc 2")
+        >>> doc2 = Document(text="text2", id_="doc 2")  # doctest: +SKIP
 
         ```
         The `add_documents` method has the `genereate_id` parameter, which is set to True by default to generate a
         sha256 hash number as a doc_id based on the content of the nodes:
         ```python
-        >>> index.add_documents([doc2])
+        >>> index.add_documents([doc2])  # doctest: +SKIP
         >>> print(index.doc_ids) # doctest: +SKIP
         ['982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1', 'fd848ca35a6281600b5da598c7cb4d5df561e0ee63ee7cec0e98e6049996f3ff']
         ```
         If you want to keep the same doc_id, you can set the `generate_id` parameter to False:
         ```python
-        >>> index.add_documents([doc2], generate_id=False)
+        >>> index.add_documents([doc2], generate_id=False)  # doctest: +SKIP
         >>> print(index.doc_ids) # doctest: +SKIP
         ['982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1', 'doc 2']
         ```

--- a/src/llama_utils/indexing/custom_index.py
+++ b/src/llama_utils/indexing/custom_index.py
@@ -14,19 +14,22 @@ from llama_utils.utils.models import get_hugging_face_embedding
 class CustomIndex:
     """A Custom class for creating indexes using Llama."""
 
-    def __init__(self, index: VectorStoreIndex):
+    def __init__(self, index: VectorStoreIndex, embedding_model=None):
         """Initialize the CustomIndex object.
 
         Parameters
         ----------
         index: VectorStoreIndex
             The index object.
+        embedding_model: Optional, default is None.
+            The embedding model to use to create the embeddings in the index.
+
         """
         if not isinstance(index, VectorStoreIndex):
             raise ValueError("The index should be an instance of VectorStoreIndex")
         self._id = index.index_id
         self._index = index
-        self._embedding_model = get_hugging_face_embedding()
+        self._embedding_model = embedding_model or get_hugging_face_embedding()
 
     def __str__(self):
         """String representation of the CustomIndex object."""

--- a/src/llama_utils/indexing/index_manager.py
+++ b/src/llama_utils/indexing/index_manager.py
@@ -48,7 +48,7 @@ class IndexManager:
 
         ```python
         >>> from llama_utils.utils.config_loader import ConfigLoader
-        >>> config_loader = ConfigLoader()
+        >>> config_loader = ConfigLoader()  # doctest: +SKIP
 
         ```
 

--- a/src/llama_utils/utils/config_loader.py
+++ b/src/llama_utils/utils/config_loader.py
@@ -22,7 +22,7 @@ class ConfigLoader:
         ----------
         llm: Any, optional, default is llama3
             llm model to use.
-        embedding: Any, optional, default is BAAI/bge-base-en-v1.5
+        embedding: Any, optional, default is BAAI/bge-small-en-v1.5
             Embedding model to use.
 
         Examples
@@ -31,7 +31,7 @@ class ConfigLoader:
         >>> from llama_utils.utils.config_loader import ConfigLoader
         >>> config = ConfigLoader() # doctest: +SKIP
         >>> print(config.embedding) # doctest: +SKIP
-        model_name='BAAI/bge-base-en-v1.5' embed_batch_size=10 callback_manager=<llama_index.core.callbacks.base.CallbackManager object at 0x000002919C16BD40> num_workers=None max_length=512 normalize=True query_instruction=None text_instruction=None cache_folder=None
+        model_name='BAAI/bge-small-en-v1.5' embed_batch_size=10 callback_manager=<llama_index.core.callbacks.base.CallbackManager object at 0x000002919C16BD40> num_workers=None max_length=512 normalize=True query_instruction=None text_instruction=None cache_folder=None
         >>> print(config.llm.model) # doctest: +SKIP
         llama3
 

--- a/src/llama_utils/utils/models.py
+++ b/src/llama_utils/utils/models.py
@@ -154,7 +154,11 @@ def get_hugging_face_embedding(
     model_name: str, optional, default is "BAAI/bge-base-en-v1.5"
         Name of the hugging face embedding model.
     cache_folder: str, optional, default is None
-        Folder to cache the model.
+        Folder to cache the model. If not provided the function will search for
+        - `LLAMA_INDEX_CACHE_DIR` in your environment variables.
+        - `~/tmp/llama_index` if your OS is Linux.
+        - `~/Library/Caches/llama_index` if your OS is MacOS.
+        - `~/AppData/Local/llama_index` if your OS is Windows.
 
     Returns
     -------

--- a/src/llama_utils/utils/models.py
+++ b/src/llama_utils/utils/models.py
@@ -145,13 +145,13 @@ def get_ollama_llm(
 
 
 def get_hugging_face_embedding(
-    model_name: str = "BAAI/bge-base-en-v1.5", cache_folder: str = None
+    model_name: str = "BAAI/bge-small-en-v1.5", cache_folder: str = None
 ):
     """Get the hugging face embedding model.
 
     Parameters
     ----------
-    model_name: str, optional, default is "BAAI/bge-base-en-v1.5"
+    model_name: str, optional, default is "BAAI/bge-small-en-v1.5"
         Name of the hugging face embedding model.
     cache_folder: str, optional, default is None
         Folder to cache the model. If not provided the function will search for
@@ -175,7 +175,7 @@ def get_hugging_face_embedding(
     >>> from llama_utils.utils.models import get_hugging_face_embedding
     >>> embedding = get_hugging_face_embedding()
     >>> print(embedding.model_name)
-    BAAI/bge-base-en-v1.5
+    BAAI/bge-small-en-v1.5
     >>> print(embedding.max_length)
     512
     >>> print(embedding.embed_batch_size)

--- a/tests/indexing/test_custom_index.py
+++ b/tests/indexing/test_custom_index.py
@@ -1,9 +1,9 @@
 import pytest
 from llama_index.core import VectorStoreIndex
 from llama_index.core.data_structs.data_structs import IndexDict
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.schema import Document, TextNode
 from llama_index.core.vector_stores import SimpleVectorStore
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 
 from llama_utils.indexing.custom_index import CustomIndex
 
@@ -87,18 +87,13 @@ def test_metadata(text_node: TextNode):
 
 class TestProperties:
     def test_embedding_model(self, vector_store_index: VectorStoreIndex):
-        c_index = CustomIndex(vector_store_index)
-        assert isinstance(c_index.embedding_model, HuggingFaceEmbedding)
-        c_index.embedding_model = HuggingFaceEmbedding(
-            model_name="sentence-transformers/all-MiniLM-L6-v2"
-        )
-        assert (
-            c_index.embedding_model.model_name
-            == "sentence-transformers/all-MiniLM-L6-v2"
-        )
+        c_index = CustomIndex(vector_store_index, embedding_model=MockEmbedding)
+        assert c_index.embedding_model == MockEmbedding
+        c_index.embedding_model = MockEmbedding(embed_dim=768)
+        assert c_index.embedding_model.model_name == "unknown"
 
     def test_node_ids(self, vector_store_index: VectorStoreIndex):
-        c_index = CustomIndex(vector_store_index)
+        c_index = CustomIndex(vector_store_index, embedding_model=MockEmbedding)
         assert c_index.node_id_list == ["d2"]
 
 

--- a/tests/utils/test_config_loader.py
+++ b/tests/utils/test_config_loader.py
@@ -1,16 +1,18 @@
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.llms import MockLLM
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.settings import _Settings
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
-from llama_index.llms.ollama import Ollama
 
 from llama_utils.utils.config_loader import ConfigLoader
 
 
 def test_config_loader():
-    config = ConfigLoader()
-    assert isinstance(config.llm, Ollama)
+    mock_embedding = MockEmbedding(embed_dim=768)
+    llm = MockLLM()
+    config = ConfigLoader(llm=llm, embedding=mock_embedding)
+    assert isinstance(config.llm, MockLLM)
     assert isinstance(config.settings, _Settings)
-    assert isinstance(config.embedding, HuggingFaceEmbedding)
+    assert isinstance(config.embedding, MockEmbedding)
     assert config.settings.llm == config.llm
     assert config.settings.embed_model == config.embedding
     assert isinstance(config.settings.text_splitter, SentenceSplitter)

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -34,9 +34,9 @@ def test_azure_open_ai():
 
 
 def test_embedding():
-    model = get_hugging_face_embedding()
+    model = get_hugging_face_embedding(model_name="BAAI/bge-small-en-v1.5")
     assert isinstance(model, HuggingFaceEmbedding)
-    assert model.model_name == "BAAI/bge-base-en-v1.5"
+    assert model.model_name == "BAAI/bge-small-en-v1.5"
     assert model.cache_folder is None
     assert model.max_length == 512
 

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -15,12 +15,24 @@ from llama_utils.utils.models import (
 
 
 def test_get_ollama_llm():
-    llm = get_ollama_llm()
-    assert isinstance(llm, Ollama)
-    assert llm.context_window == 3900
-    assert llm.model == "llama3"
-    assert llm.request_timeout == 360.0
-    assert llm.temperature == 0.75
+    with patch("llama_index.llms.ollama.Ollama") as mock_ollama:
+        instance = MagicMock()
+        mock_ollama.return_value = instance
+
+        llm = get_ollama_llm()
+        assert llm == instance
+        mock_ollama.assert_called_once_with(
+            model="llama3",
+            base_url="http://localhost:11434",
+            temperature=0.75,
+            context_window=DEFAULT_CONTEXT_WINDOW,
+            request_timeout=360.0,
+            prompt_key="prompt",
+            json_mode=False,
+            additional_kwargs={},
+            is_function_calling_model=True,
+            keep_alive=None,
+        )
 
 
 def test_azure_open_ai():


### PR DESCRIPTION
# Description
- The `CustomIndex` class has an extra parameter `embedding_model`  to specify the embedding model. 
- all the classmethods of the `CustomIndex` are also adjusted to take the extra parameter `embedding_model` 
- change the default embedding model from the `get_hugging_face_embedding` to be "BAAI/bge-small-en-v1.5"

- Fixes
- #27 
- #28 
## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests
- `MockEmbedding` is used instead of a real embedding model from hugging face models. in the following tests
`tests/indexing/test_custom_index.py::TestProperties::test_embedding_model`
`tests/indexing/test_custom_index.py::TestProperties::test_node_ids`
- `MockEmbedding` and `MockLLM` models are used in the `test_condig_loader.py`
- Mocked objects are used in the `test_models.py::test_get_ollama_llm` 
- Small embedding model `BAAI/bge-small-en-v1.5` (150 mbyte) is used in the end to end test instead of the base model (450 mbyte).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] updated environment.yml and the lock file.
- [x] added changes to change-log.md.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
